### PR TITLE
Update setup-teslausb

### DIFF
--- a/setup/pi/setup-teslausb
+++ b/setup/pi/setup-teslausb
@@ -108,6 +108,10 @@ function headless_setup_mark_setup_success () {
 function headless_setup_progress_flash () {
   if [ $USE_LED_FOR_SETUP_PROGRESS = "true" ] && [ $HEADLESS_SETUP = "true" ]
   then
+    if [ ! -f /etc/stage_flash ]
+    then
+	    get_script /etc stage_flash pi-gen-sources/00-teslausb-tweaks/files
+    fi
     /etc/stage_flash $1
   fi
 }
@@ -546,6 +550,12 @@ if [ ! -z ${AP_SSID:+x} ]
 then
   get_script /tmp configure-ap.sh setup/pi
   /tmp/configure-ap.sh
+fi
+
+# ensure there is the correct rc.local file
+if ! grep -q 'telsa' /etc/rc.local
+then
+  get_script /etc rc.local pi-gen-sources/00-teslausb-tweaks/files
 fi
 
 make_root_fs_readonly


### PR DESCRIPTION
I noticed, I missed a step somewhere and I did not have the /etc/stage_flash and /etc/rc.local, and so I added a feature to pull it automatically in setup-teslausb.

Below is the error that I saw.

```
./setup-teslausb
Read setup info from teslausb_setup_variables.conf (yes/no/cancel)? yes
reading config from /boot/teslausb_setup_variables.conf
./setup-teslausb is up to date
Updating package index files...
Hit:1 http://archive.raspberrypi.org/debian buster InRelease
Hit:2 http://raspbian.raspberrypi.org/raspbian buster InRelease
Reading package lists... Done
./setup-teslausb: line 111: /etc/stage_flash: No such file or directory
```